### PR TITLE
Update fetch-inventory.sh to drop MY2023, add MY2025

### DIFF
--- a/scripts/fetch-inventory.sh
+++ b/scripts/fetch-inventory.sh
@@ -17,7 +17,7 @@ do
       "pagesize": 300,
       "pagestart": 0,
       "filter": {
-          "year": [2023, 2024], 
+          "year": [2024, 2025], 
           "series": ["tacoma", "4runner", "tundra", "rav4", "landcruiser"], 
           "dealers": ["'$i'"],
           "andfields": ["accessory", "packages", "dealer"]


### PR DESCRIPTION
A user [in the 4G Tacoma forum on TacomaWorld](https://www.tacomaworld.com/threads/2025-tacomas.844005/page-11#post-30328467) asked if the scraper could be updated to include MY25 and drop MY23.